### PR TITLE
Fix potential security issue regarding the private GPG key

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v2.1.7
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build and Analyze with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v2.1.7
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Configure Git user


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/jaxb-parent-pom/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: GH Actions

### Description

It was brought to our attention that our current workflows might leak our private GPG key into the cached artifacts. Just caching `.m2/repository` instead of the full `.m2` folder fixes that potential issue since then, `.m2/settings.xml` (which contains the GPG key) is not cached anymore.